### PR TITLE
Update required onnx runtime version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ set(USE_SYSTEM_ONNXRUNTIME
     CACHE STRING "Use system ONNX Runtime")
 if(USE_SYSTEM_ONNXRUNTIME)
   if(OS_LINUX)
-    find_package(Onnxruntime 1.14.1 REQUIRED)
+    find_package(Onnxruntime 1.16.3 REQUIRED)
     set(Onnxruntime_INCLUDE_PATH
         ${Onnxruntime_INCLUDE_DIR} ${Onnxruntime_INCLUDE_DIR}/onnxruntime
         ${Onnxruntime_INCLUDE_DIR}/onnxruntime/core/session ${Onnxruntime_INCLUDE_DIR}/onnxruntime/core/providers/cpu)


### PR DESCRIPTION
The fetched onnx has been updated to 1.16.3 in https://github.com/occ-ai/obs-backgroundremoval/commit/1d51cdc420a2a2e1f00fdf47d01b60a4f2af8a8d but not for the system one `USE_SYSTEM_ONNXRUNTIME`