### PR TITLE
Add a flag to build without GPU support on Linux

### DIFF
--- a/cmake/FetchOnnxruntime.cmake
+++ b/cmake/FetchOnnxruntime.cmake
@@ -8,6 +8,10 @@ set(CUSTOM_ONNXRUNTIME_HASH
     ""
     CACHE STRING "Hash of a downloaded ONNX Runtime tarball")
 
+set(DISABLE_ONNXRUNTIME_GPU
+    OFF
+    CACHE STRING "Disables GPU support of ONNX Runtime (Only valid on Linux)")
+
 set(Onnxruntime_VERSION "1.16.3")
 
 if(CUSTOM_ONNXRUNTIME_URL STREQUAL "")
@@ -105,6 +109,9 @@ else()
         ${Onnxruntime_LINK_LIBS} "${onnxruntime_SOURCE_DIR}/lib/libonnxruntime_providers_shared.so"
         "${onnxruntime_SOURCE_DIR}/lib/libonnxruntime_providers_cuda.so"
         "${onnxruntime_SOURCE_DIR}/lib/libonnxruntime_providers_tensorrt.so")
+  endif()
+  if(DISABLE_ONNXRUNTIME_GPU)
+    target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE DISABLE_ONNXRUNTIME_GPU)
   endif()
   target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE ${Onnxruntime_LINK_LIBS})
   target_include_directories(${CMAKE_PROJECT_NAME} SYSTEM PUBLIC "${onnxruntime_SOURCE_DIR}/include")

--- a/src/ort-utils/ort-session-utils.cpp
+++ b/src/ort-utils/ort-session-utils.cpp
@@ -5,7 +5,8 @@
 #include <coreml_provider_factory.h>
 #endif
 
-#if defined(__linux__) && defined(__x86_64__) && !defined(DISABLE_ONNXRUNTIME_GPU)
+#if defined(__linux__) && defined(__x86_64__) && \
+	!defined(DISABLE_ONNXRUNTIME_GPU)
 #include <tensorrt_provider_factory.h>
 #endif
 
@@ -62,7 +63,8 @@ int createOrtSession(filter_data *tf)
 #endif
 
 	try {
-#if defined(__linux__) && defined(__x86_64__) && !defined(DISABLE_ONNXRUNTIME_GPU)
+#if defined(__linux__) && defined(__x86_64__) && \
+	!defined(DISABLE_ONNXRUNTIME_GPU)
 		if (tf->useGPU == USEGPU_TENSORRT) {
 			Ort::ThrowOnError(
 				OrtSessionOptionsAppendExecutionProvider_Tensorrt(

--- a/src/ort-utils/ort-session-utils.cpp
+++ b/src/ort-utils/ort-session-utils.cpp
@@ -5,7 +5,7 @@
 #include <coreml_provider_factory.h>
 #endif
 
-#if defined(__linux__) && defined(__x86_64__)
+#if defined(__linux__) && defined(__x86_64__) && !defined(DISABLE_ONNXRUNTIME_GPU)
 #include <tensorrt_provider_factory.h>
 #endif
 
@@ -62,7 +62,7 @@ int createOrtSession(filter_data *tf)
 #endif
 
 	try {
-#if defined(__linux__) && defined(__x86_64__)
+#if defined(__linux__) && defined(__x86_64__) && !defined(DISABLE_ONNXRUNTIME_GPU)
 		if (tf->useGPU == USEGPU_TENSORRT) {
 			Ort::ThrowOnError(
 				OrtSessionOptionsAppendExecutionProvider_Tensorrt(


### PR DESCRIPTION
Closes #523 

```
cmake . -B build_x86_64 \
  -DQT_VERSION=6 \
  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
  -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
  -DENABLE_FRONTEND_API=ON \
  -DENABLE_QT=ON \
  -DUSE_SYSTEM_ONNXRUNTIME=ON \
  -DDISABLE_ONNXRUNTIME_GPU=ON
```