### PR TITLE
Improve the handling of path string

### DIFF
--- a/src/FilterData.h
+++ b/src/FilterData.h
@@ -30,9 +30,9 @@ struct filter_data : public ORTModelData {
 	std::mutex outputLock;
 
 #if _WIN32
-	const wchar_t *modelFilepath = nullptr;
+	std::wstring modelFilepath;
 #else
-	const char *modelFilepath = nullptr;
+	std::string modelFilepath;
 #endif
 };
 

--- a/src/background-filter.cpp
+++ b/src/background-filter.cpp
@@ -367,9 +367,9 @@ void background_filter_update(void *data, obs_data_t *settings)
 	obs_log(LOG_INFO, "  Blur Focus Depth: %f", tf->blurFocusDepth);
 	obs_log(LOG_INFO, "  Disabled: %s", tf->isDisabled ? "true" : "false");
 #ifdef _WIN32
-	obs_log(LOG_INFO, "  Model file path: %S", tf->modelFilepath);
+	obs_log(LOG_INFO, "  Model file path: %S", tf->modelFilepath.c_str());
 #else
-	obs_log(LOG_INFO, "  Model file path: %s", tf->modelFilepath);
+	obs_log(LOG_INFO, "  Model file path: %s", tf->modelFilepath.c_str());
 #endif
 }
 

--- a/src/ort-utils/ort-session-utils.cpp
+++ b/src/ort-utils/ort-session-utils.cpp
@@ -13,6 +13,7 @@
 #ifdef _WIN32
 #include <dml_provider_factory.h>
 #include <wchar.h>
+#include <windows.h>
 #endif // _WIN32
 
 #include <obs-module.h>
@@ -51,16 +52,17 @@ int createOrtSession(filter_data *tf)
 	}
 
 	std::string modelFilepath_s(modelFilepath_rawPtr);
-	bfree(modelFilepath_rawPtr);
 
 #if _WIN32
-	std::wstring modelFilepath_ws(modelFilepath_s.size(), L' ');
-	std::copy(modelFilepath_s.begin(), modelFilepath_s.end(),
-		  modelFilepath_ws.begin());
-	tf->modelFilepath = modelFilepath_ws;
+    int outLength = MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, modelFilepath_rawPtr, -1, nullptr, 0);
+	wchar_t outWchars[outLength]:
+	MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, modelFilepath_rawPtr, -1, outWchars, outLength);
+	tf->modelFilepath = std::wstring(outWchars, outLength);
 #else
-	tf->modelFilepath = modelFilepath_s;
+	tf->modelFilepath = std::string(modelFilepath_rawPtr);
 #endif
+
+	bfree(modelFilepath_rawPtr);
 
 	try {
 #if defined(__linux__) && defined(__x86_64__) && \

--- a/src/ort-utils/ort-session-utils.cpp
+++ b/src/ort-utils/ort-session-utils.cpp
@@ -92,8 +92,8 @@ int createOrtSession(filter_data *tf)
 					sessionOptions, coreml_flags));
 		}
 #endif
-		tf->session.reset(new Ort::Session(*tf->env, tf->modelFilepath.c_str(),
-						   sessionOptions));
+		tf->session.reset(new Ort::Session(
+			*tf->env, tf->modelFilepath.c_str(), sessionOptions));
 	} catch (const std::exception &e) {
 		obs_log(LOG_ERROR, "%s", e.what());
 		return OBS_BGREMOVAL_ORT_SESSION_ERROR_STARTUP;

--- a/src/ort-utils/ort-session-utils.cpp
+++ b/src/ort-utils/ort-session-utils.cpp
@@ -56,10 +56,9 @@ int createOrtSession(filter_data *tf)
 #if _WIN32
 	int outLength = MultiByteToWideChar(
 		CP_ACP, MB_PRECOMPOSED, modelFilepath_rawPtr, -1, nullptr, 0);
-	std::vector<wchar_t> outWchars(outLength);
+	tf->modelFilepath = std::wstring(outLength, L'\0');
 	MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, modelFilepath_rawPtr, -1,
-			    outWchars.data(), outLength);
-	tf->modelFilepath = std::wstring(outWchars.begin(), outWchars.end());
+			    tf->modelFilepath.data(), outLength);
 #else
 	tf->modelFilepath = std::string(modelFilepath_rawPtr);
 #endif

--- a/src/ort-utils/ort-session-utils.cpp
+++ b/src/ort-utils/ort-session-utils.cpp
@@ -57,9 +57,9 @@ int createOrtSession(filter_data *tf)
 	std::wstring modelFilepath_ws(modelFilepath_s.size(), L' ');
 	std::copy(modelFilepath_s.begin(), modelFilepath_s.end(),
 		  modelFilepath_ws.begin());
-	tf->modelFilepath = modelFilepath_ws.c_str();
+	tf->modelFilepath = modelFilepath_ws;
 #else
-	tf->modelFilepath = modelFilepath_s.c_str();
+	tf->modelFilepath = modelFilepath_s;
 #endif
 
 	try {
@@ -92,7 +92,7 @@ int createOrtSession(filter_data *tf)
 					sessionOptions, coreml_flags));
 		}
 #endif
-		tf->session.reset(new Ort::Session(*tf->env, tf->modelFilepath,
+		tf->session.reset(new Ort::Session(*tf->env, tf->modelFilepath.c_str(),
 						   sessionOptions));
 	} catch (const std::exception &e) {
 		obs_log(LOG_ERROR, "%s", e.what());

--- a/src/ort-utils/ort-session-utils.cpp
+++ b/src/ort-utils/ort-session-utils.cpp
@@ -56,10 +56,10 @@ int createOrtSession(filter_data *tf)
 #if _WIN32
 	int outLength = MultiByteToWideChar(
 		CP_ACP, MB_PRECOMPOSED, modelFilepath_rawPtr, -1, nullptr, 0);
-	wchar_t outWchars[outLength];
+	std::vector<wchar_t> outWchars(outLength);
 	MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, modelFilepath_rawPtr, -1,
-			    outWchars, outLength);
-	tf->modelFilepath = std::wstring(outWchars, (size_t)outLength);
+			    outWchars.data(), outLength);
+	tf->modelFilepath = std::wstring(outWchars.begin(), outWchars.end());
 #else
 	tf->modelFilepath = std::string(modelFilepath_rawPtr);
 #endif

--- a/src/ort-utils/ort-session-utils.cpp
+++ b/src/ort-utils/ort-session-utils.cpp
@@ -54,9 +54,11 @@ int createOrtSession(filter_data *tf)
 	std::string modelFilepath_s(modelFilepath_rawPtr);
 
 #if _WIN32
-    int outLength = MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, modelFilepath_rawPtr, -1, nullptr, 0);
-	wchar_t outWchars[outLength]:
-	MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, modelFilepath_rawPtr, -1, outWchars, outLength);
+	int outLength = MultiByteToWideChar(
+		CP_ACP, MB_PRECOMPOSED, modelFilepath_rawPtr, -1, nullptr, 0);
+	wchar_t outWchars[outLength];
+	MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, modelFilepath_rawPtr, -1,
+			    outWchars, outLength);
 	tf->modelFilepath = std::wstring(outWchars, outLength);
 #else
 	tf->modelFilepath = std::string(modelFilepath_rawPtr);

--- a/src/ort-utils/ort-session-utils.cpp
+++ b/src/ort-utils/ort-session-utils.cpp
@@ -59,7 +59,7 @@ int createOrtSession(filter_data *tf)
 	wchar_t outWchars[outLength];
 	MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, modelFilepath_rawPtr, -1,
 			    outWchars, outLength);
-	tf->modelFilepath = std::wstring(outWchars, outLength);
+	tf->modelFilepath = std::wstring(outWchars, (size_t)outLength);
 #else
 	tf->modelFilepath = std::string(modelFilepath_rawPtr);
 #endif


### PR DESCRIPTION
Closes #525 

Given `std::string s`, `s.c_str()` will be released when `s` is released. If you want to use `s.c_str()` later, you have to hold `s` until you use `s.c_str()`.

On Windows, char paths are stored as multi-byte characters which Windows defines and it is hard to manipulate them with C++ standard libraries (codecvt was deprecated in C++17) so I propose to convert multi-byte characters with Windows-specific API that is guaranteed to work with multi-byte characters on Windows. 