### PR TITLE
Add documentation for Debian users

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ The pre-built binary of this plugin can run Ubuntu 22.04 or later.
 
 On openSUSE, please see [`docs/BUILDING-OPENSUSE.md`](docs/BUILDING-OPENSUSE.md).
 
+On Debian, you cannot use our deb package and we only support FlatPak
+installation.
+
 On other Linux distros, use the FlatHub installation of both OBS and this plugin.
 If you install OBS in a way other than FlatHub, you have to build this plugin by yourself (see instructions for building [below](#linux)).
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The pre-built binary of this plugin can run Ubuntu 22.04 or later.
 
 On openSUSE, please see [`docs/BUILDING-OPENSUSE.md`](docs/BUILDING-OPENSUSE.md).
 
-On Debian, you cannot use our deb package and we only support FlatPak
+On Debian, you cannot use our deb package and we only support FlatHub
 installation.
 
 On other Linux distros, use the FlatHub installation of both OBS and this plugin.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ On Debian, you cannot use our deb package and we only support FlatPak
 installation.
 
 On other Linux distros, use the FlatHub installation of both OBS and this plugin.
+
+```
+flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+flatpak install flathub com.obsproject.Studio
+flatpak install flathub com.obsproject.Studio.Plugin.BackgroundRemoval
+```
+
 If you install OBS in a way other than FlatHub, you have to build this plugin by yourself (see instructions for building [below](#linux)).
 
 ## Code Walkthrough


### PR DESCRIPTION
Closes #533 

We provide the FlatPak distribution of our plugin for distributions other than Ubuntu, and they include Debian. However, many users misunderstand that the deb package is for Debian users, and the issues they report consume our time in a void.
To avoid inefficient communication, I suppose we should state that we only support FlatPak installation on Debian.